### PR TITLE
add CHAN token metadata

### DIFF
--- a/assets/mainnet/5HhZcSuYHEBr6GmvuDEu6k4u3rRfv7VtJrJtjZPUEtGK/token.json
+++ b/assets/mainnet/5HhZcSuYHEBr6GmvuDEu6k4u3rRfv7VtJrJtjZPUEtGK/token.json
@@ -1,0 +1,12 @@
+{
+  "name": "Chan Token",
+  "symbol": "CHAN",
+  "decimals": 9,
+  "address": "5HhZcSuYHEBr6GmvuDEu6k4u3rRfv7VtJrJtjZPUEtGK",
+  "logoURI": "https://raw.githubusercontent.com/datahacker40/chan-token-assets/main/chanlogo.png",
+  "tags": ["memecoin"],
+  "extensions": {
+    "website": "https://tuweb.com",
+    "twitter": "https://twitter.com/tuusuario"
+  }
+}


### PR DESCRIPTION
---
This PR adds the CHAN token to the Solana Token Registry.

- **Name:** Chan Token
- **Symbol:** CHAN
- **Decimals:** 6
- **Mint Address:** 5HhZcSuYHEBr6GmvuDEu6k4u3rRfv7VtJrJtjZPUEtGK
- **Logo URI:** https://raw.githubusercontent.com/datahacker40/chan-token-assets/main/chanlogo.png
- **Tags:** memecoin